### PR TITLE
Day 8 - Add post-fix baseline exports after cleanup

### DIFF
--- a/sql/exports/day8_negative_quantities_after_fix.csv
+++ b/sql/exports/day8_negative_quantities_after_fix.csv
@@ -1,0 +1,1 @@
+order_id,customer_name,product_id,quantity,order_date

--- a/sql/exports/day8_orphan_orders_after_fix.csv
+++ b/sql/exports/day8_orphan_orders_after_fix.csv
@@ -1,0 +1,1 @@
+order_id,customer_name,product_id,quantity,order_date

--- a/sql/exports/day8_total_ordered_vs_stock_after_fix.csv
+++ b/sql/exports/day8_total_ordered_vs_stock_after_fix.csv
@@ -1,0 +1,9 @@
+product_id,product_name,stock_quantity,total_ordered,remaining_stock
+5,"Laptop Dell XPS 13",5,3,2
+2,"Mechanical Keyboard",5,1,4
+1,"Wireless Mouse",9,2,7
+8,"Standing Desk 120x60",9,0,9
+6,"IPhone 14",14,3,11
+7,"Office Chair Ergonomic",20,0,20
+9,"Coffee Beans Brazil 1kg",50,20,30
+4,Notebook,50,0,50


### PR DESCRIPTION
Adds verified after-fix CSV exports for all three data validation cases (Over-order, Orphan Orders, Negative Quantities).