### PR TITLE
Day 9 – API Testing (Postman): add mock DB + collection + env + README

### DIFF
--- a/postman/README_Day9.md
+++ b/postman/README_Day9.md
@@ -1,0 +1,44 @@
+# Day 9 - Local JSON Server & Postman Tests
+
+## Objective
+Learning how to work with local REST API using `json-server` and testing endpoints in `Postman`.
+
+---
+
+## Configuration
+
+### Server startup
+In `postman/` directory:
+```bash
+json-server --watch day9_db.json --port 3000
+```
+API avaiable under:
+```text
+http://localhost:3000/products
+```
+
+---
+
+## Tests in Postman:
+
+### Tested endpoints
+1. GET /products - list of all products.
+2. GET /products/:id - details about product.
+3. POST /products - adding new product.
+4. PUT /products/:id - update product.
+5. DELETE /products/:id - delete product.
+
+### Used Collections:
+- day9_collection.json
+- day9_environment.json
+
+### Results saved id:
+- day9_postman_test_run_results.json
+
+---
+
+## Results
+- Local API based on json-server
+- Complete collection of tests in `Postman`
+- Auto-saving `productId` after `POST`
+- Correct assertions of statuses and answer types

--- a/postman/day9_collection.json
+++ b/postman/day9_collection.json
@@ -1,0 +1,244 @@
+{
+	"info": {
+		"_postman_id": "b10667d4-a6e0-4bba-a0ba-6333915e0c58",
+		"name": "Day 9 - Products CRUD",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "48587973",
+		"_collection_link": "https://k-cisinski-5566912.postman.co/workspace/Krystian's-Workspace~2cbbc229-7eb7-4de2-886b-35f75214b7a3/collection/48587973-b10667d4-a6e0-4bba-a0ba-6333915e0c58?action=share&source=collection_link&creator=48587973"
+	},
+	"item": [
+		{
+			"name": "Create product - POST /products",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status is 200 or 201\", function () {\r",
+							"    pm.expect(pm.response.code).to.be.oneOf([200, 201]);\r",
+							"});\r",
+							"\r",
+							"pm.test(\"Response is JSON\", function() {\r",
+							"    pm.response.to.be.json;\r",
+							"});\r",
+							"\r",
+							"let jsonData;\r",
+							"pm.test(\"Response is parsable JSON and contains id\", function() {\r",
+							"    pm.expect(function() {jsonData = pm.response.json(); }).not.to.throw();\r",
+							"    pm.expect(jsonData.id, \"id not found\").to.be.ok;\r",
+							"    pm.environment.set(\"productId\", jsonData.id);\r",
+							"    console.log(\"Saved productId\", jsonData.id);\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"id\": \"11\",\r\n    \"title\": \"QA Test Product\",\r\n    \"price\": 25.5,\r\n    \"description\": \"Created during Day 9 tests\",\r\n    \"category\": \"electronics\",\r\n    \"image\": \"https://i.pravatar.cc\",\r\n    \"rating\": {\r\n        \"rate\": 4.2,\r\n        \"count\": 37\r\n      }\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{baseUrl}}/products",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"products"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GET /products (list)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status is 200\", () => pm.response.to.have.status(200));\r",
+							"\r",
+							"pm.test(\"Response is JSON array\", () => {\r",
+							"    const json = pm.response.json();\r",
+							"    pm.expect(Array.isArray(json)).to.be.true;\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"title\": \"QA Test Product\",\r\n    \"price\": 25.5,\r\n    \"image\": \"https://i.pravatar.cc\",\r\n    \"category\": \"electronics\"\r\n}"
+				},
+				"url": {
+					"raw": "{{baseUrl}}/products",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"products"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GET single - GET /products/{{productId}}",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status is 200\", () => pm.response.to.have.status(200));\r",
+							"pm.test(\"Response is JSON\", () => pm.response.to.be.json);\r",
+							"pm.test(\"Response contains same id as environment productId\", () => {\r",
+							"    const json = pm.response.json();\r",
+							"    pm.expect(json.id).to.eql(String(pm.environment.get(\"productId\")));\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"title\": \"QA Test Product\",\r\n    \"price\": 25.5,\r\n    \"image\": \"https://i.pravatar.cc\",\r\n    \"category\": \"electronics\"\r\n}"
+				},
+				"url": {
+					"raw": "{{baseUrl}}/products/{{productId}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"products",
+						"{{productId}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "PUT /products/{{productId}} (update)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status is 200\", () => pm.response.to.have.status(200));\r",
+							"\r",
+							"pm.test(\"Response contains updated title\", () => {\r",
+							"    const json = pm.response.json();\r",
+							"    pm.expect(json.title).to.eql(\"QA Test Product - Updated\");\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "PUT",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"title\": \"QA Test Product - Updated\",\r\n  \"price\": 29.99,\r\n  \"description\": \"Updated during Day 9 tests\",\r\n  \"category\": \"electronics\",\r\n  \"image\": \"https://i.pravatar.cc\"\r\n}\r\n",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{baseUrl}}/products/{{productId}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"products",
+						"{{productId}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "DELETE /products/{{productId}}",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status is 200\", () => pm.response.to.have.status(200));\r",
+							"\r",
+							"pm.test(\"Deleted resource check\", () => {\r",
+							"    const json = pm.response.json();\r",
+							"    // json returns deleted object - checking id existance\r",
+							"    pm.expect(json.id).to.eql(String(pm.environment.get(\"productId\")));\r",
+							"    // remove variable\r",
+							"    pm.environment.unset(\"productId\");\r",
+							"});"
+						],
+						"type": "text/javascript",
+						"packages": {}
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "DELETE",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"title\": \"QA Test Product - Updated\",\r\n  \"price\": 29.99,\r\n  \"description\": \"Updated during Day 9 tests\",\r\n  \"category\": \"electronics\",\r\n  \"image\": \"https://i.pravatar.cc\"\r\n}\r\n"
+				},
+				"url": {
+					"raw": "{{baseUrl}}/products/{{productId}}",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"products",
+						"{{productId}}"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/postman/day9_db.json
+++ b/postman/day9_db.json
@@ -1,0 +1,124 @@
+{
+  "products": [
+    {
+      "id": "1",
+      "title": "Fjallraven - Foldsack No. 1 Backpack, Fits 15 Laptops",
+      "price": 109.95,
+      "description": "Your perfect pack for everyday use and walks in the forest.",
+      "category": "men's clothing",
+      "image": "https://fakestoreapi.com/img/81fPKd-2AYL._AC_SL1500_t.png",
+      "rating": {
+        "rate": 3.9,
+        "count": 120
+      }
+    },
+    {
+      "id": "2",
+      "title": "Mens Casual Premium Slim Fit T-Shirts",
+      "price": 22.3,
+      "description": "Slim-fitting style, contrast raglan long sleeve...",
+      "category": "men's clothing",
+      "image": "https://fakestoreapi.com/img/71-3HjGNDUL._AC_SY879._SX._UX._SY._UY_t.png",
+      "rating": {
+        "rate": 4.1,
+        "count": 259
+      }
+    },
+    {
+      "id": "3",
+      "title": "Mens Cotton Jacket",
+      "price": 55.99,
+      "description": "Great outerwear jackets for Spring/Autumn/Winter...",
+      "category": "men's clothing",
+      "image": "https://fakestoreapi.com/img/71li-ujtlUL._AC_UX679_t.png",
+      "rating": {
+        "rate": 4.7,
+        "count": 500
+      }
+    },
+    {
+      "id": "4",
+      "title": "Mens Casual Slim Fit",
+      "price": 15.99,
+      "description": "The color could be slightly different between on the screen and in practice.",
+      "category": "men's clothing",
+      "image": "https://fakestoreapi.com/img/71YXzeOuslL._AC_UY879_t.png",
+      "rating": {
+        "rate": 2.1,
+        "count": 430
+      }
+    },
+    {
+      "id": "5",
+      "title": "John Hardy Women's Legends Naga Gold & Silver Dragon Station Chain Bracelet",
+      "price": 695,
+      "description": "From our Legends Collection, the Naga was inspired by the mythical water dragon...",
+      "category": "jewelery",
+      "image": "https://fakestoreapi.com/img/71pWzhdJNwL._AC_UL640_QL65_ML3_t.png",
+      "rating": {
+        "rate": 4.6,
+        "count": 400
+      }
+    },
+    {
+      "id": "6",
+      "title": "Solid Gold Petite Micropave",
+      "price": 168,
+      "description": "Satisfaction Guaranteed. Return or exchange any order within 30 days.",
+      "category": "jewelery",
+      "image": "https://fakestoreapi.com/img/61sbMiUnoGL._AC_UL640_QL65_ML3_t.png",
+      "rating": {
+        "rate": 3.9,
+        "count": 70
+      }
+    },
+    {
+      "id": "7",
+      "title": "White Gold Plated Princess",
+      "price": 9.99,
+      "description": "Classic Created Wedding Engagement Solitaire Diamond Promise Ring for Her.",
+      "category": "jewelery",
+      "image": "https://fakestoreapi.com/img/71YAIFU48IL._AC_UL640_QL65_ML3_t.png",
+      "rating": {
+        "rate": 3,
+        "count": 400
+      }
+    },
+    {
+      "id": "8",
+      "title": "Pierced Owl Rose Gold Plated Stainless Steel Double",
+      "price": 10.99,
+      "description": "Rose Gold Plated Double Flared Tunnel Plug Earrings.",
+      "category": "jewelery",
+      "image": "https://fakestoreapi.com/img/51UDEzMJVpL._AC_UL640_QL65_ML3_t.png",
+      "rating": {
+        "rate": 1.9,
+        "count": 100
+      }
+    },
+    {
+      "id": "9",
+      "title": "WD 2TB Elements Portable External Hard Drive - USB 3.0",
+      "price": 64,
+      "description": "USB 3.0 and USB 2.0 Compatibility Fast data transfers...",
+      "category": "electronics",
+      "image": "https://fakestoreapi.com/img/61IBBVJvSDL._AC_SY879_t.png",
+      "rating": {
+        "rate": 3.3,
+        "count": 203
+      }
+    },
+    {
+      "id": "10",
+      "title": "SanDisk SSD PLUS 1TB Internal SSD - SATA III 6 Gb/s",
+      "price": 109,
+      "description": "Easy upgrade for faster boot up, shutdown, application load and response.",
+      "category": "electronics",
+      "image": "https://fakestoreapi.com/img/61U7T1koQqL._AC_SX679_t.png",
+      "rating": {
+        "rate": 2.9,
+        "count": 470
+      }
+    }
+  ]
+}

--- a/postman/day9_env.json
+++ b/postman/day9_env.json
@@ -1,0 +1,15 @@
+{
+	"id": "7e695179-dc08-42db-a589-b508e6aabe4d",
+	"name": "Local (Day9)",
+	"values": [
+		{
+			"key": "baseUrl",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2025-10-11T15:58:56.564Z",
+	"_postman_exported_using": "Postman/11.63.6"
+}

--- a/postman/day9_postman_test_run_results.json
+++ b/postman/day9_postman_test_run_results.json
@@ -1,0 +1,219 @@
+{
+	"id": "09591db9-ece3-46be-b279-dbcb205dec7a",
+	"name": "Day 9 - Products CRUD",
+	"timestamp": "2025-10-11T15:55:11.510Z",
+	"collection_id": "48587973-b10667d4-a6e0-4bba-a0ba-6333915e0c58",
+	"folder_id": 0,
+	"environment_id": "48587973-7e695179-dc08-42db-a589-b508e6aabe4d",
+	"totalPass": 12,
+	"delay": 0,
+	"persist": true,
+	"status": "finished",
+	"startedAt": "2025-10-11T15:55:10.668Z",
+	"totalFail": 0,
+	"results": [
+		{
+			"id": "eb8f44d8-33d8-4a6f-a5a2-62fc78e69fe4",
+			"name": "Create product - POST /products",
+			"url": "http://localhost:3000/products",
+			"time": 9,
+			"responseCode": {
+				"code": 201,
+				"name": "Created"
+			},
+			"tests": {
+				"Status is 200 or 201": true,
+				"Response is JSON": true,
+				"Response is parsable JSON and contains id": true
+			},
+			"testPassFailCounts": {
+				"Status is 200 or 201": {
+					"pass": 1,
+					"fail": 0
+				},
+				"Response is JSON": {
+					"pass": 1,
+					"fail": 0
+				},
+				"Response is parsable JSON and contains id": {
+					"pass": 1,
+					"fail": 0
+				}
+			},
+			"times": [
+				9
+			],
+			"allTests": [
+				{
+					"Status is 200 or 201": true,
+					"Response is JSON": true,
+					"Response is parsable JSON and contains id": true
+				}
+			]
+		},
+		{
+			"id": "400577bc-3d01-4306-b084-b81387799763",
+			"name": "GET /products (list)",
+			"url": "http://localhost:3000/products",
+			"time": 3,
+			"responseCode": {
+				"code": 200,
+				"name": "OK"
+			},
+			"tests": {
+				"Status is 200": true,
+				"Response is JSON array": true
+			},
+			"testPassFailCounts": {
+				"Status is 200": {
+					"pass": 1,
+					"fail": 0
+				},
+				"Response is JSON array": {
+					"pass": 1,
+					"fail": 0
+				}
+			},
+			"times": [
+				3
+			],
+			"allTests": [
+				{
+					"Status is 200": true,
+					"Response is JSON array": true
+				}
+			]
+		},
+		{
+			"id": "e3b4d1f9-5fc5-4119-b9eb-1f5133a0c4fc",
+			"name": "PUT /products/{{productId}} (update)",
+			"url": "http://localhost:3000/products/11",
+			"time": 4,
+			"responseCode": {
+				"code": 200,
+				"name": "OK"
+			},
+			"tests": {
+				"Status is 200": true,
+				"Response contains updated title": true
+			},
+			"testPassFailCounts": {
+				"Status is 200": {
+					"pass": 1,
+					"fail": 0
+				},
+				"Response contains updated title": {
+					"pass": 1,
+					"fail": 0
+				}
+			},
+			"times": [
+				4
+			],
+			"allTests": [
+				{
+					"Status is 200": true,
+					"Response contains updated title": true
+				}
+			]
+		},
+		{
+			"id": "69cd8469-dc16-4c9a-9550-d40e49007c3a",
+			"name": "GET single - GET /products/{{productId}}",
+			"url": "http://localhost:3000/products/11",
+			"time": 4,
+			"responseCode": {
+				"code": 200,
+				"name": "OK"
+			},
+			"tests": {
+				"Status is 200": true,
+				"Response is JSON": true,
+				"Response contains same id as environment productId": true
+			},
+			"testPassFailCounts": {
+				"Status is 200": {
+					"pass": 1,
+					"fail": 0
+				},
+				"Response is JSON": {
+					"pass": 1,
+					"fail": 0
+				},
+				"Response contains same id as environment productId": {
+					"pass": 1,
+					"fail": 0
+				}
+			},
+			"times": [
+				4
+			],
+			"allTests": [
+				{
+					"Status is 200": true,
+					"Response is JSON": true,
+					"Response contains same id as environment productId": true
+				}
+			]
+		},
+		{
+			"id": "2fc29621-f84f-4283-aa1e-52eda83207e8",
+			"name": "DELETE /products/{{productId}}",
+			"url": "http://localhost:3000/products/11",
+			"time": 5,
+			"responseCode": {
+				"code": 200,
+				"name": "OK"
+			},
+			"tests": {
+				"Status is 200": true,
+				"Deleted resource check": true
+			},
+			"testPassFailCounts": {
+				"Status is 200": {
+					"pass": 1,
+					"fail": 0
+				},
+				"Deleted resource check": {
+					"pass": 1,
+					"fail": 0
+				}
+			},
+			"times": [
+				5
+			],
+			"allTests": [
+				{
+					"Status is 200": true,
+					"Deleted resource check": true
+				}
+			]
+		}
+	],
+	"count": 1,
+	"totalTime": 25,
+	"collection": {
+		"requests": [
+			{
+				"id": "eb8f44d8-33d8-4a6f-a5a2-62fc78e69fe4",
+				"method": "POST"
+			},
+			{
+				"id": "400577bc-3d01-4306-b084-b81387799763",
+				"method": "GET"
+			},
+			{
+				"id": "e3b4d1f9-5fc5-4119-b9eb-1f5133a0c4fc",
+				"method": "PUT"
+			},
+			{
+				"id": "69cd8469-dc16-4c9a-9550-d40e49007c3a",
+				"method": "GET"
+			},
+			{
+				"id": "2fc29621-f84f-4283-aa1e-52eda83207e8",
+				"method": "DELETE"
+			}
+		]
+	}
+}


### PR DESCRIPTION
This PR adds deliverables for Day 9 - API Testing:
- postman/day9_db.json – local mock database (json-server) with sample products (IDs 1-10, based on fakestoreapi data)
- postman/day9_collection.json – exported Postman collection with CRUD requests (POST, GET list, GET single, PUT, DELETE) and tests
- postman/day9_env.json – exported environment (baseUrl = http://localhost:3000)
- postman/README_Day9.md - contains all necessary instructions
